### PR TITLE
Add packages: `tree` and `ncdu`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -191,6 +191,8 @@ install_dependencies() {
     PACKAGES=(
         "aria2"
         "btop"
+        "tree"
+        "ncdu"
         "gdal-bin"
         "git"
         "jq"


### PR DESCRIPTION
I love to use niroku to quickly setup Raspberry Pis !

I would like to propose the addition of some standard packages and will submit this pull request.

This pull request adds two useful utilities to the list of installed packages in the `install.sh` script.

New package installations:

- Added `tree` to the `PACKAGES` array to provide a command-line directory listing tool.
  - The tree command displays the hierarchical structure of the files and subdirectories in a specified directory in tree format. Using this command makes it easy to visually understand the project structure and folder structure.
- Added `ncdu` to the `PACKAGES` array to enable disk usage analysis from the command line.
  - The ncdu command is a disk usage analyzer that uses ncurses, and is a tool that allows you to interactively display and manage disk space usage on a terminal. It is similar to the du command, but is more intuitive and helps you understand large files and directories.

## Screenshots

### tree

[![Image from Gyazo](https://i.gyazo.com/135160101e9e64d30c660efdaf65b172.png)](https://gyazo.com/135160101e9e64d30c660efdaf65b172)

### ncdu

[![Image from Gyazo](https://i.gyazo.com/958940d43f6ee41d29f9ce9c203b2c2b.png)](https://gyazo.com/958940d43f6ee41d29f9ce9c203b2c2b)
